### PR TITLE
Further styling updates to adjust the margin

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookie-banner.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookie-banner.scss
@@ -4,14 +4,14 @@
 
   box-sizing: border-box;
   width: 100%;
-
+  display:none !important;
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
   background-color: lighten(desaturate(govuk-colour("light-blue"), 8.46), 42.55);
 }
 
 .app-cookie-banner {
-  display: none;
+  display: none !important  ;
 }
 
 @include govuk-media-query($media-type: print) {

--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -70,6 +70,9 @@
     }
 }
 
+.gem-c-cookie-banner__buttons .govuk-button {
+  margin-bottom : 5px
+}
 .gem-c-cookie-banner__button.govuk-grid-column-one-half-from-desktop {
     padding: 0;
 }
@@ -269,9 +272,10 @@
         line-height: 1.15;
     }
 }
-.cookie-settings-confirmation {
+.cookie-settings__confirmation {
 	display:none;
 }
+
 .gem-c-notice {
     color: #0b0c0c;
     padding: 15px;


### PR DESCRIPTION
1. Further styling updates to adjust the margin bottom for Cookie Banner - New toolkit
2. To temporarily hiding old cookie banner (Blue banner on top) , added style in _cookie-banner.scss