### PR TITLE
Further styling updates to adjust confirmation-message

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -111,6 +111,9 @@
 .gem-c-cookie-banner__hide-button {
     display: block;
 }
+.gem-c-cookie-banner .gem-c-cookie-banner__confirmation .gem-c-cookie-banner__confirmation-message {
+  margin-bottom: 0;
+}
 
 @media (min-width: 48.0625em) {
     .gem-c-cookie-banner__confirmation-message,

--- a/src/gds_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -109,6 +109,11 @@
     display: block;
 }
 
+.gem-c-cookie-banner .gem-c-cookie-banner__confirmation .gem-c-cookie-banner__confirmation-message {
+  margin-bottom: 0;
+}
+
+
 @media (min-width: 48.0625em) {
     .gem-c-cookie-banner__confirmation-message,
     .gem-c-cookie-banner__hide-button {
@@ -184,7 +189,11 @@
         right: 5px;
     }
 }
+/* Hide old cookie banner */
 
+#global-cookie-message.app-cookie-banner {
+  display: none !important;
+}
 .gem-c-cookie-banner#global-cookie-message {
     background-color: #f3f2f1;
     padding: 20px 0;


### PR DESCRIPTION
1. Further styling updates to adjust the margin of confirmation message on Cookie Banner
2. Temporarily hiding old cookie banner (Blue banner on top)  for old toolkit