### PR TITLE
Cookie Banner Resolution Updates

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -71,7 +71,8 @@
 }
 
 .gem-c-cookie-banner__buttons .govuk-button {
-  margin-bottom : 5px
+  margin-bottom : 5px;
+  width: 100%;
 }
 .gem-c-cookie-banner__button.govuk-grid-column-one-half-from-desktop {
     padding: 0;
@@ -382,4 +383,10 @@
         font-size: 14pt;
         line-height: 1.15
     }
+}
+
+@media (max-width: 40.0525em) {
+  .gem-c-cookie-banner .govuk-form-group {
+    margin-bottom: 0;
+  }
 }

--- a/src/gds_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -375,6 +375,9 @@
     cursor: pointer;
     -webkit-appearance: none;
 }
+.gem-c-cookie-banner .govuk-grid-column-full {
+    width: 100%;
+}
 
 @media print {
     .gem-c-cookie-banner .govuk-button {


### PR DESCRIPTION
Following updates made
1. Cookie banner resolution updates  showing buttons 100% wide in mobile and tablet view
2. Reduce the gap between set cookie preference button and main header when viewing on mobile resolution