### PR TITLE
Updated cookie-preferences nojs show hide sections

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -390,3 +390,15 @@
     margin-bottom: 0;
   }
 }
+
+.js-enabled .cookie-settings__no-js {
+    display: none
+}
+
+.js-enabled .cookie-settings__form-wrapper {
+    display: block
+}
+
+.cookie-settings__form-wrapper {
+    display: none
+}

--- a/src/gds_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -645,4 +645,19 @@
         margin-bottom:20px
     }
 }
-.gem-c-cookie-banner#global-cookie-message p {font-size: 19px}
+
+.gem-c-cookie-banner#global-cookie-message p {
+  font-size: 19px;
+}
+
+.js-enabled .cookie-settings__no-js {
+    display: none
+}
+
+.js-enabled .cookie-settings__form-wrapper {
+    display: block
+}
+
+.cookie-settings__form-wrapper {
+    display: none
+}


### PR DESCRIPTION
Updated cookie-preferences nojs show hide sections for following toolkits in _cookies.scss

1. gds_toolkit
2. gds_service_toolkit