### PR TITLE
Cookie banner margin update for gds toolkit BAU

### DIFF
--- a/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_cookies.scss
@@ -673,3 +673,6 @@
 .cookie-settings__form-wrapper {
     display: none
 }
+.gem-c-cookie-banner .govuk-form-group {
+  margin-bottom:0px;
+}


### PR DESCRIPTION
Updated BAU toolkit adjust gap between cookie banner buttons and page header