### PR TITLE
DFC 12643 vulnerability and upgrade Jquery in gds_service_toolkit

### DIFF
--- a/src/gds_service_toolkit/package-lock.json
+++ b/src/gds_service_toolkit/package-lock.json
@@ -2463,9 +2463,9 @@
       "optional": true
     },
     "grunt": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
-      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.1.0.tgz",
+      "integrity": "sha512-+NGod0grmviZ7Nzdi9am7vuRS/h76PcWDsV635mEXF0PEQMUV6Kb+OjTdsVxbi0PZmfQOjCMKb3w8CVZcqsn1g==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -2479,9 +2479,9 @@
         "grunt-legacy-log": "~2.0.0",
         "grunt-legacy-util": "~1.1.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.13.0",
+        "js-yaml": "~3.13.1",
         "minimatch": "~3.0.2",
-        "mkdirp": "~0.5.1",
+        "mkdirp": "~1.0.3",
         "nopt": "~3.0.6",
         "path-is-absolute": "~1.0.0",
         "rimraf": "~2.6.2"
@@ -2498,6 +2498,12 @@
             "nopt": "~3.0.6",
             "resolve": "~1.1.0"
           }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         }
       }
     },
@@ -3493,9 +3499,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
     "jquery-validation": {
       "version": "1.19.0",

--- a/src/gds_service_toolkit/package.json
+++ b/src/gds_service_toolkit/package.json
@@ -6,13 +6,13 @@
     "govuk-frontend": "^2.5.1",
     "govuk_frontend_toolkit": "9.0.0",
     "html5shiv": "^3.7.3",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.0",
     "jquery-validation": "^1.19.0",
     "jquery-validation-unobtrusive": "^3.2.11"
   },
   "devDependencies": {
     "clean-css": "^4.1.9",
-    "grunt": "^1.0.4",
+    "grunt": "^1.1.0",
     "grunt-concurrent": "^2.3.1",
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-copy": "^1.0.0",
@@ -20,11 +20,11 @@
     "grunt-contrib-cssmin": "^2.2.1",
     "grunt-contrib-imagemin": "^3.1.0",
     "grunt-contrib-uglify": "^3.0.1",
+    "grunt-contrib-uglify-es": "^3.3.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-newer": "^1.3.0",
     "grunt-sass": "~2.0.0",
     "load-grunt-tasks": "^3.5.2",
-    "time-grunt": "^1.4.0",
-    "grunt-contrib-uglify-es": "^3.3.0"
+    "time-grunt": "^1.4.0"
   }
 }


### PR DESCRIPTION
1. Upgraded Jquery from 3.4.1 to 3.5.0  to resolve vulnerabilities
2. Grunt upgrade

Note: Upgraded **gds_service_toolkit** testing and identify any issues with upgrade before upgrading **gds_service_toolkit_BAU** & **gds_toolkit**