### PR TITLE
Bug/DFC-12741 DYSAC SHC - Green bar styling should be below the nav b…

### DIFF
--- a/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_cookies.scss
@@ -676,3 +676,6 @@
 .gem-c-cookie-banner .govuk-form-group {
   margin-bottom:0px;
 }
+.govuk-header__container {
+    margin-bottom: -10px;
+}


### PR DESCRIPTION
…ar not within

Updated __cookies.scss as the order of precedence changed once cookie banner implemented in DYSAC - SHC