### PR TITLE
BUG-DFC-13074-SIT Cooking settings page - The "javascript disabled" c…

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_cookies.scss
@@ -391,12 +391,14 @@
   }
 }
 
-// Show none js version by default
-.cookie-settings__no-js {
-    display: block;
+.js-enabled .cookie-settings__no-js {
+    display: none
 }
 
-// Hide js version by default
+.js-enabled .cookie-settings__form-wrapper {
+    display: block
+}
+
 .cookie-settings__form-wrapper {
-    display: block;
+    display: none
 }


### PR DESCRIPTION
…ontent reverting back css change

BUG-DFC-13074- SIT > Cooking settings page: The "javascript disabled" content is showing irrespective of whether javascript is enabled or not. : Reverted back changes from Sumair