### PR TITLE
DFC-13093 Exam results helpline | Hide message displayed when javascr…

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_custom.scss
@@ -8,3 +8,20 @@
 		}
 	}
 }
+.global-bar__dismiss--show {
+  display:none !important;
+}
+.js-enabled {
+  .global-bar__dismiss--show {
+    display:block !important;
+  }
+}
+@media (max-width: 48.0525em) {
+    .global-bar {
+      .global-bar-message-container {
+        .global-bar__dismiss {
+          margin-left:50px;
+        }
+      }
+    }
+}

--- a/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_custom.scss
@@ -552,17 +552,36 @@ $mobile: 768px;
       }
     }
 }
-
-@media (min-width: 1020px) {
-    .global-bar .global-bar-message-container {
-        margin:0 auto
-    }
+.global-bar__dismiss--show {
+  display:none !important;
+}
+.js-enabled {
+  .global-bar__dismiss--show {
+    display:block !important;
+  }
 }
 .govuk-\!-margin-top-1 {
     margin-top: 5px!important
 }
+@media (min-width: 1020px) {
+    .global-bar {
+      .global-bar-message-container {
+        margin:0 auto;
+    }
+  }
+}
+
 @media (min-width: 40.0625em) {
     .govuk-\!-margin-top-1 {
         margin-top:5px!important
     }
+ }
+ @media (max-width: 48.0525em) {
+     .global-bar {
+       .global-bar-message-container {
+         .global-bar__dismiss {
+           margin-left:50px;
+         }
+       }
+     }
  }

--- a/src/gds_toolkit/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_toolkit/assets/src/frontend/sass/includes/_custom.scss
@@ -93,6 +93,14 @@
 		margin-top:5px!important;
 	}
 }
+.global-bar__dismiss--show {
+  display:none !important;
+}
+.js-enabled {
+  .global-bar__dismiss--show {
+    display:block !important;
+  }
+}
 
 @media (min-width: 40.0625em) {
     .global-bar {
@@ -116,4 +124,14 @@
 			margin:0 auto
 		}
 	}
+}
+
+@media (max-width: 48.0525em) {
+    .global-bar {
+      .global-bar-message-container {
+        .global-bar__dismiss {
+          margin-left:50px;
+        }
+      }
+    }
 }

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_custom-banner.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_custom-banner.scss
@@ -90,3 +90,20 @@ $global-bar-background-colour: #ffdd00;
         margin-top:5px!important;
     }
  }
+ .global-bar__dismiss--show {
+   display:none !important;
+ }
+ .js-enabled {
+   .global-bar__dismiss--show {
+     display:block !important;
+   }
+ }
+ @media (max-width: 48.0525em) {
+     .global-bar {
+       .global-bar-message-container {
+         .global-bar__dismiss {
+           margin-left:50px;
+         }
+       }
+     }
+ }


### PR DESCRIPTION
…ipt is disabled

Exam results helpline: Hide message displayed when javascript is disabled - Updated styles to address the issue
2. Mobile view overlapping issue fixed