### PR TITLE
BUG-DFC-13122 Exam results helpline | Font size is reduced on comp ui…

### DIFF
--- a/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_service_toolkit_BAU/assets/src/frontend/sass/includes/_custom.scss
@@ -606,6 +606,10 @@ $mobile: 768px;
         margin-top:5px!important
     }
  }
+ .global-bar.global-bar--warning {
+     background-color: #ffdd00;
+     font-size: 119%;
+ }
  @media (max-width: 48.0525em) {
      .global-bar {
        .global-bar-message-container {
@@ -621,4 +625,8 @@ $mobile: 768px;
          }
        }
      }
+     .global-bar.global-bar--warning {
+      font-size:100%;
+      line-height: normal;
+    }
  }

--- a/src/gds_toolkit/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_toolkit/assets/src/frontend/sass/includes/_custom.scss
@@ -130,6 +130,8 @@
 @media (max-width: 48.0525em) {
     .global-bar {
       .global-bar-message-container {
+        margin: 0 15px;
+        
         .global-bar__dismiss {
           margin-left:50px;
           position: relative !important;

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_custom-banner.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_custom-banner.scss
@@ -47,7 +47,7 @@ $global-bar-background-colour: #ffdd00;
         display: block;
         padding-left: 50px;
         font-weight: normal;
-        font-size: inherit;
+        font-size: 115%;
         font-weight: bold;
 
         .govuk-warning-text__assistive {
@@ -71,6 +71,7 @@ $global-bar-background-colour: #ffdd00;
        margin-top: 0;
        right: 0;
        top: 0;
+       font-size: 113%;
 
        &:focus {
            outline: transparent solid 3px;


### PR DESCRIPTION
… job profile page

Updated COMPUI (nationalcareers_toolkit) to adjust the font size of the Job Profile page Exam Helpline banner, to make it consistent with other pages.

Only JP page using nationalcareers_toolkit. Rest of the pages are using old toolkits - gds_toolkit, gds_service_toolkit, gds_service_toolkit_BAU

In addition to that, on Mobile view, banners are not consistent in few of the pages where we use gds_toolkit & gds_service_toolkit

issues fixed for the mobile view are

1. the gap between lines in SHC Banner
2. font size is bigger in SHC banner
3. Left and right margin is more in the home page where gds_servcice_toolkit is been used