### PR TITLE
BUG-DFC-13123-Exam-results-helpline-On-mobile-view-Warning-Icon-verti…

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_custom-banner.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_custom-banner.scss
@@ -40,8 +40,8 @@ $global-bar-background-colour: #ffdd00;
         user-select: none;
 
         @media (max-width: 48.0525em) {
-              top: 45%;
-              margin-top: 0;
+              top: 45% !important;
+              margin-top: 0 !important;
         }
     }
     strong.govuk-warning-text__text {


### PR DESCRIPTION
…cally-positioned-top

Further updates to add precedence of mobile Warning Icon positioning style on nationalcareers_toolkit