### PR TITLE
BUG-DFC-13125-Exam results helpline | Icon is misaligned on iPad mini…

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_custom.scss
@@ -22,6 +22,8 @@
         .global-bar__dismiss {
           margin-left:50px;
           float: left;
+          postion: relative;
+          margin-top:10px;
         }
         .govuk-warning-text__icon {
           top:45%;


### PR DESCRIPTION
… when the banner is hidden

Updated style on gds_service_toolkit to fix the positioning of show message hyperlink