### PR TITLE
BUG-DFC-13125  Exam-results-helpline-Icon-is-misaligned-on-iPad-mini-…

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/includes/_custom.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/includes/_custom.scss
@@ -22,7 +22,7 @@
         .global-bar__dismiss {
           margin-left:50px;
           float: left;
-          postion: relative;
+          position: relative;
           margin-top:10px;
         }
         .govuk-warning-text__icon {


### PR DESCRIPTION
…when-the-banner-is-hidden

Fixed the spelling mistake