### PR TITLE
BUG-DFCC-1159 Add-GDS-color-custom-classes-for-missing-modern-colors-…

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/components/_colors.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/components/_colors.scss
@@ -157,6 +157,7 @@ $error-background: #fef7f7;       // Error background colour
 
 // Standard palette, greys
 .black-background { background-color : $black }
+.dark-grey-background { background-color : $dark-grey }
 .mid-grey-background { background-color : $mid-grey }
 .light-grey-background { background-color : $light-grey }
 .grey-1-background { background-color :  $grey-1 }

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/components/_colors.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/components/_colors.scss
@@ -43,7 +43,6 @@ $yellow-50: #ffdf94;
 $yellow-25: #fff2d3;
 $grass-green: #85994b;
 $light-green: #85994b;
-$light-green: #85994b;
 $grass-green-50: #c2cca3;
 $grass-green-25: #e7ebda;
 $green: #00703c;
@@ -158,6 +157,8 @@ $error-background: #fef7f7;       // Error background colour
 
 // Standard palette, greys
 .black-background { background-color : $black }
+.mid-grey-background { background-color : $mid-grey }
+.light-grey-background { background-color : $light-grey }
 .grey-1-background { background-color :  $grey-1 }
 .grey-2-background  { background-color : $grey-2 }
 .grey-3-background  { background-color : $grey-3 }

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/components/_colors.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/components/_colors.scss
@@ -5,11 +5,14 @@ $careers-turquoise: #207e77;
 $govuk-blue: #005ea5;
 $mainstream-brand: $govuk-blue;
 $ncs-green: #207e77;
+$govuk-brand-colour : #1d70b8;
 
 // Standard palette, colours
-$purple: #2e358b;
+$purple: #4c2c92;
 $purple-50: #9799c4;
 $purple-25: #d5d6e7;
+$light-purple: #6f72af;
+$bright-purple: #912b88;
 $mauve: #6f72af;
 $mauve-50: #b7b9d7;
 $mauve-25: #e2e2ef;
@@ -17,12 +20,13 @@ $fuschia: #912b88;
 $fuschia-50: #c994c3;
 $fuschia-25: #e9d4e6;
 $pink: #d53880;
+$light-pink: #f499be;
 $pink-50: #eb9bbe;
 $pink-25: #f6d7e5;
 $baby-pink: #f499be;
 $baby-pink-50: #faccdf;
 $baby-pink-25: #fdebf2;
-$red: #b10e1e;
+$red: #d4351c;
 $red-50: #d9888c;
 $red-25: #efcfd1;
 $mellow-red: #df3034;
@@ -34,35 +38,42 @@ $orange-25: #fde4d4;
 $brown: #b58840;
 $brown-50: #dac39c;
 $brown-25: #f0e7d7;
-$yellow: #ffbf47;
+$yellow: #ffdd00;
 $yellow-50: #ffdf94;
 $yellow-25: #fff2d3;
 $grass-green: #85994b;
+$light-green: #85994b;
+$light-green: #85994b;
 $grass-green-50: #c2cca3;
 $grass-green-25: #e7ebda;
-$green: #006435;
+$green: #00703c;
 $green-50: #7fb299;
 $green-25: #cce0d6;
 $turquoise: #28a197;
 $turquoise-50: #95d0cb;
 $turquoise-25: #d5ecea;
-$light-blue: #2b8cc4;
+$blue: #1d70b8;
+$light-blue: #5694ca;
 $light-blue-50: #96c6e2;
 $light-blue-25: #d5e8f3;
+$dark-blue: #003078;
 
 // Standard palette, greys
 $black: #0b0c0c;
-$grey-1: #6f777b;
+$grey-1: #505a5f;
 $grey-2: #bfc1c3;
 $grey-3: #dee0e2;
 $grey-4: #f8f8f8;
-$white: #fff;
+$dark-grey: #505a5f;
+$mid-grey: #b1b4b6;
+$light-grey: #f3f2f1;
+$white: #ffffff;
 
 // Semantic colour names
 $link-colour: $govuk-blue;
 $link-active-colour: $light-blue;
-$link-hover-colour: $light-blue;
-$link-visited-colour: #4c2c92;
+$link-hover-colour: $dark-blue;
+$link-visited-colour: $purple;
 $button-colour: #00823b;
 $focus-colour: $yellow;
 $text-colour: $black;             // Standard text colour
@@ -82,6 +93,8 @@ $error-background: #fef7f7;       // Error background colour
 
 
 // Standard GDS colour styles
+.mainstream-brand { color: $mainstream-brand;}
+.govuk-brand-colour{ color:  $govuk-brand-colour;}
 .ncs-green { color: $ncs-green }
 .ncs-green-background { background-color: $ncs-green }
 .purple { color: $purple }
@@ -114,7 +127,7 @@ $error-background: #fef7f7;       // Error background colour
 .yellow{ color: $yellow }
 .yellow-50{ color: $yellow-50 }
 .yellow-25{ color: $yellow-25 }
-.grass-green{ color: $grass-green }
+.grass-green, .light-green { color: $grass-green }
 .grass-green-50{ color: $grass-green-50 }
 .grass-green-25{ color: $grass-green-25 }
 .green{ color: $green }
@@ -126,14 +139,19 @@ $error-background: #fef7f7;       // Error background colour
 .light-blue{ color: $light-blue }
 .light-blue-50{ color: $light-blue-50 }
 .light-blue-25{ color: $light-blue-25 }
+.dark-blue { color: $dark-blue }
+
 
 // Standard palette, greys
-.black { color : $black }
-.grey-1 { color :  $grey-1 }
-.grey-2  { color : $grey-2 }
-.grey-3  { color : $grey-3 }
-.grey-4 { color : $grey-4 }
-.white  { color : $white }
+.black{ color : $black }
+.dark-grey{ color : $dark-grey }
+.mid-grey{ color :$mid-grey }
+.light-grey{ color : $light-grey }
+.grey-1{ color :  $grey-1 }
+.grey-2{ color : $grey-2 }
+.grey-3{ color : $grey-3 }
+.grey-4{ color : $grey-4 }
+.white{ color : $white }
 
 
 // Standard palette background, greys
@@ -148,6 +166,7 @@ $error-background: #fef7f7;       // Error background colour
 
 
 // Standard GDS background-colour styles
+.govuk-blue { background-color: $govuk-blue }
 .ncs-green-background { background-color: $ncs-green }
 .purple-background { background-color: $purple }
 .purple-50-background { background-color: $purple-50 }
@@ -188,10 +207,11 @@ $error-background: #fef7f7;       // Error background colour
 .turquoise-background { background-color: $turquoise }
 .turquoise-50-background { background-color: $turquoise-50 }
 .turquoise-25-background { background-color: $turquoise-25 }
+.blue-background { background-color: $blue }
 .light-blue-background { background-color: $light-blue }
 .light-blue-50-background { background-color: $light-blue-50 }
 .light-blue-25-background { background-color: $light-blue-25 }
-
+.dark-blue-background { background-color: $dark-blue }
 
 // Semantic colour names classes
 .link-colour { color : $link-colour !important;}


### PR DESCRIPTION
…to-replae-inline-styles

Missing colors added
#505a5f (secondary text / dark grey)

#1d70b8 (govuk blue / blue, brand colour, links) - no background

#003078 (dark blue, hover links) - no background

#b1b4b6 (border, mid-grey)

#4c2c92 should be purple as well as link visited

#ffdd00 should be yellow colourd

#4351c should be red / error state

#00703c should be green

#5694ca should be light blue