### PR TITLE
BUG-DFC-12823- Device-Phone-view-Menu-console-error-is-generated-each…

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/js/jp-feedback.js
+++ b/src/gds_service_toolkit/assets/src/frontend/js/jp-feedback.js
@@ -82,7 +82,7 @@
         GOVUK.addCookieMessage();
     }
 
-    // header navigation toggle
+    /* header navigation toggle
     if (document.querySelectorAll && document.addEventListener){
         var els = document.querySelectorAll('.js-header-toggle'),
             i, _i;
@@ -105,7 +105,7 @@
                 }
             });
         }
-    }
+    }*/
 }).call(this);
 
 $(document).ready(function () {


### PR DESCRIPTION
…-time-that-the-link-is-clicked

Commented out the event listener assuming this code block is not used to make menu open / close. Need further testing on DEV server before proceed to remove the code block completely