### PR TITLE
STORY-DFC-13315-Styling-fixes-and-code-changes-for-toolkit-skills-count

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/js/custom-validation.js
+++ b/src/gds_service_toolkit/assets/src/frontend/js/custom-validation.js
@@ -39,30 +39,6 @@ $(document).ready(function () {
     $("#DateOfBirthYear").change(function () {
         PopulateDateOfBirth();
     });
-
-    //// *** Pre Serch filters - Skills accordion selected skills count  ***
-    $("#accordion-filter-skills-list input[type=checkbox]").each(function () {
-        $(this).change(updateCount);
-    });
-
-    function updateCount() {
-      var count = $("#accordion-filter-skills-list input[type=checkbox]:checked").length;
-      $("#continueForm #count span").text(count);
-    }
-
-    //// *** Pre Serch filters - Skills accordion  section selected skills count  ***
-    function updateSectionCount() {
-      var sectionCounts = $(this).closest('.govuk-accordion__section').find("input[type=checkbox]:checked").length;
-      $(this).closest('.govuk-accordion__section').find('.section-count').text(sectionCounts).toggle(sectionCounts > 0)
-    }
-
-    $('#accordion-filter-skills-list .govuk-accordion__section').each(function() {
-      var sectionCount = $(this).closest('.govuk-accordion__section').find("input[type=checkbox]:checked").length;;
-      $('.section-count').toggle(sectionCount > 0);
-      $("input[type=checkbox]").each(function () {
-        $(this).change(updateSectionCount);
-      });
-    })
 });
 
 $.validator.setDefaults({

--- a/src/gds_service_toolkit/assets/src/frontend/js/dfcdigital.js
+++ b/src/gds_service_toolkit/assets/src/frontend/js/dfcdigital.js
@@ -67,6 +67,38 @@ $(".skip-filter").click(function () {
 });
 
 
+/* Pre Serch filters - skills count */
+var skillsCheckboxes = $("#accordion-filter-skills-list input[type=checkbox]");
+skillsCheckboxes.each(function () {
+  $(this).change(updateCount);
+});
+
+function updateCount() {
+	var target = $(this),
+	parent = target.closest('.govuk-accordion__section'),
+	checked = parent.find('input[type="checkbox"]:checked'),
+	checkedAll = $('#accordion-filter-skills-list input[type="checkbox"]:checked').length,
+	sectionCount = parent.find('.section-count'),
+
+	sectionCountLength = checked.length,
+	count = $("#count span");
+
+	count.text(checkedAll);
+	sectionCount.text(sectionCountLength).toggle(sectionCountLength > 0);
+}
+
+/* retain skills selection on browser back or forward*/
+$(window).on("load", function() {
+	updateCount();
+
+	/* accordion section selected checkbox count again */
+	var accordionSection = $('#accordion-filter-skills-list .govuk-accordion__section');
+	accordionSection.each(function () {
+  	var sectionCheckedLength = $(this).find('input[type="checkbox"]:checked').length;
+		$(this).find('.section-count').text(sectionCheckedLength).toggle(sectionCheckedLength > 0);
+	});
+});
+
 });
 
 $.extend($.ui.autocomplete.prototype, {

--- a/src/gds_service_toolkit/assets/src/frontend/sass/patterns/psf.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/patterns/psf.scss
@@ -39,8 +39,31 @@
        opacity: 1
   }
 
-  //custom govuk-checkboxes--small 
-  .govuk-checkboxes--small {
+  .govuk-checkboxes__label {
+    	span {
+        display: block;
+        padding-right: 15px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        font-weight: 400;
+        font-size: 16px;
+        line-height: 1.25;
+        display: block;
+        margin-bottom: 15px;
+        color: #505a5f;
+
+        @media (min-width: 40.0625em) {
+          font-size: 19px;
+          line-height: 1.31579;
+        }
+      }
+    }
+    .section-count {
+      display: none;
+    }
+
+    //custom govuk-checkboxes--small
+    .govuk-checkboxes--small {
       .govuk-checkboxes__item {
           min-height: 0;
           margin-bottom: 0;


### PR DESCRIPTION
1. - Skills count retain when a back button or browser 'go back' or 'go forward' button clicked
2. - Style modification to address Checkbox hint text replication
3. - Hide Count Tag on accordions section when count is 0