### PR TITLE
BUG-FT1-102-Skills-toolkit-Accordions-to-display-expanded-when-JS-is-…

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/all.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/all.scss
@@ -13,7 +13,7 @@ $govuk-assets-path: "/nationalcareers_toolkit/" !default;
 @import "includes/_service-status.scss";
 @import "includes/_cookie-banner.scss";
 @import "includes/_custom-banner.scss";
-@import "includes/_custom.scss";
+
 
 /* DYSAC imports which will be deprecated and added into custom live service patterns */
 $app-purple: #8c0052;
@@ -41,3 +41,4 @@ $app-text-light: #646C70;
 @import "compui/skills-toolkit.scss";
 /* Import all custom and default patterns */
 @import "patterns/all";
+@import "includes/_custom.scss";

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/patterns/_custom-banner.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/patterns/_custom-banner.scss
@@ -98,3 +98,54 @@ span.ncs-toggle {
         margin-top:5px!important;
     }
  }
+
+ /********************************************
+ ALL generic and pattern related CUSTOM Styles
+ should go here
+ *********************************************/
+
+ /* CUSTOM STYLES FOR ACCORDION Non Javascript Version  */
+ body .govuk-accordion__section-content {
+ 	display: block;
+ }
+ .js-enabled .govuk-accordion__section-content {
+ 	display: none;
+ }
+
+ body .govuk-accordion__section-button {
+     color: #0b0c0c;
+
+     &:focus {
+         outline: none;
+         color: #0b0c0c;
+         background-color: transparent;
+         box-shadow: none;
+         cursor: text;
+     }
+ }
+ .js-enabled .govuk-accordion__section-button {
+     color: #005ea5;
+
+     &:focus {
+         outline: transparent solid 3px;
+         color: #0b0c0c;
+         background-color: #fd0;
+         box-shadow: 0 -2px #fd0,0 4px #0b0c0c;
+     }
+ }
+ body .govuk-accordion__section-button:hover:not(:focus) {
+ 	text-decoration: none;
+   cursor: text;
+ }
+ .js-enabled .govuk-accordion__section-button:hover:not(:focus) {
+ 	text-decoration: underline;
+   cursor: pointer;
+ }
+
+ body .govuk-accordion__icon {
+     display:none;
+ }
+ .js-enabled .govuk-accordion__icon {
+     display:inline-block;
+ }
+ /* END : CUSTOM STYLES FOR ACCORDION Non Javascript Version  */


### PR DESCRIPTION
…disabled-fix

Moving the position of include file _custom.scss as well added the styles to custom-banner.scss to get the styles reflected

NOTE: This mechanism should be reverted once identify the issue with importing