### PR TITLE
ExploreCareers-Toolkit---Menu-does-not-open-when-viewing-in-mobile-no-js

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/all.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/all.scss
@@ -39,5 +39,9 @@ $app-text-light: #646C70;
 @import "compui/dfc-app-jobprofiles.scss";
 @import "compui/dfc-app-pages.scss";
 @import "compui/skills-toolkit.scss";
+
 /* Import all custom and default patterns */
 @import "patterns/all";
+
+/* Import no-js custom styles */
+@import "includes/_no-js.scss";

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_no-js.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_no-js.scss
@@ -1,0 +1,24 @@
+/*** Menu custom styles **/
+body {
+	.govuk-header__navigation {
+	    display: block;
+	    margin: 0;
+	    padding: 0;
+	    list-style: none
+	}
+	.govuk-header__menu-button {
+	    display: none;
+
+	}
+}
+.js-enabled {
+	.govuk-header__navigation {
+	    display: none
+	}
+	.govuk-header__navigation--open {
+	    display: block
+	}
+	.govuk-header__menu-button {
+	    display: block
+	}
+}


### PR DESCRIPTION
Menu Fix for javascript disabled mode