### PR TITLE
STORY-FT1-38-Hide-duplicated-headers-from-JP-accordion-sections

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/patterns/job-profiles.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/patterns/job-profiles.scss
@@ -181,17 +181,10 @@
 .job-profile-subsection {
   margin-bottom: 40px;
 
-  .job-profile-subsection-content {
-    padding-left: 20px;
-    border-left: 3px solid $grey-3;
-  }
-
   h3 {
     margin-bottom: 20px;
     font-size: 22px;
     font-weight: bold;
-    background-color: $grey-3;
-    padding: 15px 20px;
     border-radius: 5px;
   }
 
@@ -560,5 +553,11 @@
 
   .js-visible {
     display: block;
+  }
+}
+.govuk-accordion__section-content {
+  h2.job-profile-headings,
+  h2.job-profile-heading {
+    display:none;
   }
 }


### PR DESCRIPTION
Hiding duplicated headers on accordion sections in JP
Modified styles, removing header grey background in accordion section details
Removed left border for accordion section contents