### PR TITLE
BUG-DFC-13686-FaC-Location-Mobile-view-drop-down-overlaps-everything-…

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_filters.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_filters.scss
@@ -75,4 +75,10 @@
     .conditional-box {
         max-height: none;
     }
+
+    @media (max-width: 40.0625em) {
+      #location-input.govuk-input--width-10 {
+          max-width: none;
+      }
+    }
 }


### PR DESCRIPTION
…underneath

Removed max-width restriction for mobile view of Find a Course > Filter > Location search input, which makes the results display full width of mobile screen and reduces the height of results section.

Also the readability now improved as the screen utilises full width available