### PR TITLE
STORY-FT1-386-Front-end: Triage tool homepage filters styles

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/compui/dfc-app-triage.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/compui/dfc-app-triage.scss
@@ -72,3 +72,19 @@ div.dfc-app-triage-panel {
 .filters-button, .js-enabled .filters-button, body .filters-button {
     display: none
 }
+
+/* show /hide */
+.triage-tool-results {
+  display:none;
+
+  @media (max-width: 43.75em) {
+       display:block;
+   }
+}
+.triage-tool-sidebar {
+  display:block;
+
+  @media (max-width: 43.75em) {
+      display:none;
+  }
+}


### PR DESCRIPTION
Added styles to show and hide Speak to an adviser below Triage tool result filters and under results in the right panel