### PR TITLE
BUG-FT1-548-Display-of-legacy-homepage-in-STAX

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_homepage.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/includes/_homepage.scss
@@ -331,3 +331,17 @@ body.hasHover {
 .ncs-triage-select-label {
     display: inline-block;
 }
+
+.ncs-home-grid-wrapper {
+  min-height: 74px;
+
+  @media (max-width: 780px) {
+      min-height: auto;
+  }
+  @media (max-width: 715px) {
+    min-height: 100px;
+  }
+  @media (max-width: 640px) {
+    min-height: auto;
+  }
+}


### PR DESCRIPTION
Added new class '.ncs-home-grid-wrapper' to make homepage section - Skills assessment, Explore careers & Find a course - equal height and display correctly on all devices