### PR TITLE
Story/DFC-13932 ERHbanners master release from dev release 551

### DIFF
--- a/src/gds_service_toolkit/assets/src/frontend/sass/patterns/banner-bar.scss
+++ b/src/gds_service_toolkit/assets/src/frontend/sass/patterns/banner-bar.scss
@@ -152,13 +152,12 @@
 	margin-left: 0;
 
 	@media(max-width: 641px) {
+	  margin-left: 50px;
 	  line-height: 30px;
 	}
 }
 @media(max-width: 641px) {
-	.global-bar-message .ncs-banner__text {
-		line-height: 30px;
-	}
+
 	.global-bar-message .ncs-banner__separator {
 		display: none;
 	}
@@ -166,19 +165,17 @@
 		display: block;
 	}
 
-	.global-bar-message .govuk-warning-text__icon  {
+	.global-bar-message .govuk-warning-text__icon,
+  .global-bar-message-container  {
 		top: 0%;
 		margin-top: 0;
 	}
 
-	.global-bar-message-container  {
-		top: 0%;
-		margin-top: 0;
-	}
   .global-bar-message .ncs-banner__text {
     display: block;
     line-height: 21px;
     margin-top: 5px;
+    margin-left: 50px;
   }
 
   .global-bar.global-bar--warning.single-row-banner .global-bar-message-container .global-bar-message .govuk-warning-text__icon {

--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/compui/erh.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/compui/erh.scss
@@ -695,7 +695,7 @@
   }
   .erh-card-group {
     .card.card-white {
-      min-height: 145px;
+      min-height: 165px;
 
       @media(max-width: 641px) {
         min-height: 65px;


### PR DESCRIPTION
…ner-position (#586)

Styling fix for following issues
1. gds_service_toolkit > Exam Results Banner link text overlaps warning icon on left
2. nationalcareers_toolkit > Card group height issue on MaC pushing the second row card to the right instead of left due to extra line of text on Traineeship card