### PR TITLE
Removed padding from .govuk-grid-column-full

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/sass/compui/dfc-app-pages.scss
+++ b/src/nationalcareers_toolkit/assets/src/frontend/sass/compui/dfc-app-pages.scss
@@ -155,5 +155,10 @@ div.dfc-app-pages-alignment-justify {
 }
 
 .govuk-full-width-container > .govuk-grid-row{
+
+  .govuk-grid-column-full{
+    padding: 0px;
+  }
+
   margin: 0 auto;
 }


### PR DESCRIPTION
- removed padding on .govuk-grid-column-full when the class is part of a full width page