### PR TITLE
Set town and coordinates when results page is loaded from selecting a location in the DYM list

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/js/compui.bundles/dfc-app-findacourse/dfc-app-findacourse.js
+++ b/src/nationalcareers_toolkit/assets/src/frontend/js/compui.bundles/dfc-app-findacourse/dfc-app-findacourse.js
@@ -5,6 +5,7 @@ $(document).ready(function () {
         var searchTerm = urlParams.get('searchTerm');
         var town = urlParams.get('town');
         var coordinates = urlParams.get('coordinates');
+        var didYouMeanLocationParam = urlParams.get('location');
         if (searchTerm == null) {
             searchTerm = urlParams.get('SearchTerm');
         }
@@ -13,6 +14,10 @@ $(document).ready(function () {
         }
         if (coordinates == null) {
             coordinates = urlParams.get('sideBarCoordinates');
+        }
+        if (didYouMeanLocationParam != null && town == null) {
+            [town, ...coordinates] = didYouMeanLocationParam.split("|");
+            coordinates = coordinates.join('|')
         }
         
         showHideDistanceInput(distance != null && distance === "1", null);


### PR DESCRIPTION
From the current location data, there is a longitude and latitude for every location, so I feel comfortable in using the destructuring assignment syntax here to assign the values to the variables.