### PR TITLE
Revert "Strip distance parameter from link back to FAC homepage by pointing to href id"

### DIFF
--- a/src/nationalcareers_toolkit/assets/src/frontend/js/compui.bundles/dfc-app-findacourse/dfc-app-findacourse.js
+++ b/src/nationalcareers_toolkit/assets/src/frontend/js/compui.bundles/dfc-app-findacourse/dfc-app-findacourse.js
@@ -141,13 +141,8 @@ function generateClearLink(d) {
         if (element.getAttribute('href')) {
             var contactus = element.getAttribute('href').indexOf('contact-us') === -1;
             var isExternalLink = element.getAttribute('href').indexOf('http') === 0;
-            var isBackToFacLandingPage = element.id === 'back-to-fac-landing-page';
             if (!isExternalLink && contactus) {
                 element.href = element.href.replace('&D=0', '').replace('&D=1', '') + '&D=' + d;
-            }
-            // Sanitize link back to homepage of distance parameter if true
-            if (isBackToFacLandingPage) {
-                element.href = element.href.replace('&D=0', '').replace('&D=1', '');
             }
         }
     });


### PR DESCRIPTION
This is reverting a snippet of code that targeted a HTML tag by id that is also going to be removed, so will just merge this in once FACD-499 on dfc-app-findacourse checks pass.